### PR TITLE
bool to Option refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@
 
 ## To do
 
-- [ ] Refactor the `Hittable` trait so that `hit()` returns an `Option<HitRecord>` rather that a `bool`
+- [x] Refactor the `Hittable` trait so that `hit()` returns an `Option<HitRecord>` rather than a `bool`
+- [x] Refactor the `Material` trait so that `scatter()` returns an `Option` rather than a `bool`
+- [ ] Consider using an `Arc` instead of a `Box` for materials and hittables

--- a/README.md
+++ b/README.md
@@ -13,3 +13,137 @@
 - [x] Refactor the `Hittable` trait so that `hit()` returns an `Option<HitRecord>` rather than a `bool`
 - [x] Refactor the `Material` trait so that `scatter()` returns an `Option` rather than a `bool`
 - [ ] Consider using an `Arc` instead of a `Box` for materials and hittables
+
+## Learnings
+
+Following the book and translating C++ to Rust line by line is great to get the project up and running. Here are some changes I've done, after getting my final render out.
+
+### Option types instead of bools
+
+When following the book, twice we create a method that takes empty data structures as arguments that we attempt to internally mutate. If successful the method returns `true`, if not, `false`. This sounds like a job for Rust's `Option<_>` type.
+
+#### Hit Method
+
+For the `hit()` method of the `Hittable` trait, instead of passing a mutable `HitRecord`, we can remove the argument and return `Some(HitRecord)` or `None`, instead of `true` or `false`. Later, we can use `if let Some(rec)` to unwrap the value again.
+
+Before:
+
+```rust
+// src/hittable.rs
+
+fn hit(&self, r: &Ray, ray_t: Interval, rec: &mut HitRecord) -> bool {
+    let mut temp_rec = HitRecord::default();
+    let mut hit_anything = false;
+    let mut closest_so_far = ray_t.max;
+    for object in self.objects.iter() {
+        if object.hit(&r, Interval::new(ray_t.min, closest_so_far), &mut temp_rec) {
+            hit_anything = true;
+            closest_so_far = temp_rec.t;
+            *rec = temp_rec.clone();
+        }
+    }
+    hit_anything
+}
+
+// src/camera.rs
+
+let mut rec = HitRecord::default();
+if world.hit(&r, Interval::new(0.001, f32::INFINITY), &mut rec) {
+    // ...
+}
+
+```
+
+After:
+
+```rust
+// src/hittable.rs
+
+fn hit(&self, r: &Ray, ray_t: Interval) -> Option<HitRecord> {
+    let mut closest_so_far = ray_t.max;
+    let mut hit_anything = None;
+    for object in self.objects.iter() {
+        if let Some(rec) = object.hit(&r, Interval::new(ray_t.min, closest_so_far)) {
+            closest_so_far = rec.t;
+            hit_anything = Some(rec);
+        }
+    }
+    hit_anything
+}
+
+// src/camera.rs
+
+if let Some(rec) = world.hit(&r, Interval::new(0.001, f32::INFINITY)) {
+    // ...
+}
+```
+
+#### Scatter method
+
+Something similar is used in the `scatter()` method that is part of the `Material` trait. It takes a mutable vec3 `attenuation` and a mutable ray `scattered` as arguments and mutates them internally. If successful, it returns `true`. If not, `false`.
+
+Since we are dealing with two return values now, we can wrap them in a new structure I called `ScatterResult`. After that, we can wrap it once again in the `Option<_>` type.
+
+Before:
+
+```rust
+// src/material.rs
+
+fn scatter(
+    &self,
+    _r_in: &Ray,
+    rec: &HitRecord,
+    attenuation: &mut Vector3<f32>,
+    scattered: &mut Ray,
+) -> bool {
+    let mut scatter_direction = rec.normal + random_unit_vector();
+
+    if near_zero(&scatter_direction) {
+        scatter_direction = rec.normal;
+    }
+
+    *scattered = Ray::new(rec.p, scatter_direction);
+    *attenuation = self.albedo;
+    true
+}
+
+// src/camera.rs
+
+let mut scattered = Ray::default();
+let mut attenuation = Vector3::default();
+if rec.mat.scatter(r, &rec, &mut attenuation, &mut scattered) {
+    return attenuation.component_mul( & Camera::ray_color(& scattered, depth - 1, world));
+}
+
+```
+
+After:
+
+```rust
+// src/material.rs
+
+fn scatter(&self, _r_in: &Ray, rec: &HitRecord) -> Option<ScatterResult> {
+    let mut scatter_direction = rec.normal + random_unit_vector();
+
+    if near_zero(&scatter_direction) {
+        scatter_direction = rec.normal;
+    }
+
+    Some(ScatterResult {
+        attenuation: self.albedo,
+        scattered: Ray::new(rec.p, scatter_direction),
+    })
+}
+
+// src/camera.rs
+
+if let Some(scatter) = rec.mat.scatter(r, &rec) {
+    return scatter.attenuation.component_mul( & Camera::ray_color(
+        &scatter.scattered,
+        depth - 1,
+        world)
+    );
+}
+```
+
+Much cleaner :crab:

--- a/src/hittable.rs
+++ b/src/hittable.rs
@@ -1,9 +1,8 @@
 use crate::interval::Interval;
-use crate::material::{Lambertian, Material};
+use crate::material::Material;
 use crate::ray::Ray;
 use nalgebra::Vector3;
 
-#[derive(Clone)]
 pub struct HitRecord {
     pub p: Vector3<f32>,
     pub normal: Vector3<f32>,
@@ -12,13 +11,19 @@ pub struct HitRecord {
     pub front_face: bool,
 }
 
-impl Clone for Box<dyn Material> {
-    fn clone(&self) -> Box<dyn Material> {
-        self.clone_box()
-    }
-}
-
 impl HitRecord {
+    pub fn new(p: Vector3<f32>, t: f32, mat: Box<dyn Material>) -> Self {
+        Self {
+            p,
+            normal: Vector3::new(0.0, 0.0, 0.0),
+            mat,
+            t,
+            front_face: false,
+        }
+    }
+    /// Sets the hit record normal vector.
+    ///
+    /// NOTE: the parameter `outward_normal` is assumed to have unit length.
     pub fn set_face_normal(&mut self, r: &Ray, outward_normal: Vector3<f32>) {
         self.front_face = r.direction.dot(&outward_normal) < 0.0;
         self.normal = if self.front_face {
@@ -29,20 +34,14 @@ impl HitRecord {
     }
 }
 
-impl Default for HitRecord {
-    fn default() -> Self {
-        Self {
-            p: Vector3::default(),
-            normal: Vector3::default(),
-            mat: Box::new(Lambertian::new(Vector3::new(0.5, 0.5, 0.5))),
-            t: 0.0,
-            front_face: false,
-        }
+impl Clone for Box<dyn Material> {
+    fn clone(&self) -> Box<dyn Material> {
+        self.clone_box()
     }
 }
 
 pub trait Hittable {
-    fn hit(&self, r: &Ray, ray_t: Interval, rec: &mut HitRecord) -> bool;
+    fn hit(&self, r: &Ray, ray_t: Interval) -> Option<HitRecord>;
 }
 
 pub struct HittableList {
@@ -62,15 +61,13 @@ impl HittableList {
 }
 
 impl Hittable for HittableList {
-    fn hit(&self, r: &Ray, ray_t: Interval, rec: &mut HitRecord) -> bool {
-        let mut temp_rec = HitRecord::default();
-        let mut hit_anything = false;
+    fn hit(&self, r: &Ray, ray_t: Interval) -> Option<HitRecord> {
         let mut closest_so_far = ray_t.max;
+        let mut hit_anything = None;
         for object in self.objects.iter() {
-            if object.hit(&r, Interval::new(ray_t.min, closest_so_far), &mut temp_rec) {
-                hit_anything = true;
-                closest_so_far = temp_rec.t;
-                *rec = temp_rec.clone();
+            if let Some(rec) = object.hit(&r, Interval::new(ray_t.min, closest_so_far)) {
+                closest_so_far = rec.t;
+                hit_anything = Some(rec);
             }
         }
         hit_anything

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,6 +1,5 @@
 use nalgebra::Vector3;
 
-#[derive(Debug, Clone, Copy)]
 pub struct Ray {
     pub origin: Vector3<f32>,
     pub direction: Vector3<f32>,
@@ -10,17 +9,7 @@ impl Ray {
     pub fn new(origin: Vector3<f32>, direction: Vector3<f32>) -> Self {
         Self { origin, direction }
     }
-
     pub fn at(&self, t: f32) -> Vector3<f32> {
         self.origin + t * self.direction
-    }
-}
-
-impl Default for Ray {
-    fn default() -> Self {
-        Self {
-            origin: Vector3::default(),
-            direction: Vector3::default(),
-        }
     }
 }

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -11,6 +11,7 @@ pub struct Sphere {
 }
 
 impl Sphere {
+    /// Creates a new sphere from with a given position, size and material.
     pub fn new(center: Vector3<f32>, radius: f32, mat: Box<dyn Material>) -> Self {
         Self {
             center,
@@ -21,7 +22,7 @@ impl Sphere {
 }
 
 impl Hittable for Sphere {
-    fn hit(&self, r: &Ray, ray_t: Interval, rec: &mut HitRecord) -> bool {
+    fn hit(&self, r: &Ray, ray_t: Interval) -> Option<HitRecord> {
         let oc = self.center - r.origin;
         let a = r.direction.magnitude_squared();
         let h = r.direction.dot(&oc);
@@ -29,7 +30,7 @@ impl Hittable for Sphere {
 
         let discriminant = h * h - a * c;
         if discriminant < 0.0 {
-            return false;
+            return None;
         }
 
         let sqrtd = discriminant.sqrt();
@@ -38,16 +39,13 @@ impl Hittable for Sphere {
         if !ray_t.surrounds(root) {
             root = (h + sqrtd) / a;
             if !ray_t.surrounds(root) {
-                return false;
+                return None;
             }
         }
-        rec.t = root;
 
-        rec.p = r.at(rec.t);
+        let mut rec = HitRecord::new(r.at(root), root, self.mat.clone());
         let outward_normal = (rec.p - self.center) / self.radius;
-        rec.set_face_normal(r, outward_normal);
-        rec.mat = self.mat.clone();
-
-        true
+        rec.set_face_normal(&r, outward_normal);
+        Some(rec)
     }
 }

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -2,11 +2,7 @@ use nalgebra::Vector3;
 use rand::Rng;
 
 pub fn random_vector() -> Vector3<f32> {
-    Vector3::new(
-        random_float(),
-        random_float(),
-        random_float(),
-    )
+    Vector3::new(random_float(), random_float(), random_float())
 }
 
 pub fn random_float() -> f32 {
@@ -14,8 +10,8 @@ pub fn random_float() -> f32 {
     rng.gen()
 }
 
-pub fn random_float_range(min: f32, max:f32) -> f32 {
-    min + (max-min) * random_float()
+pub fn random_float_range(min: f32, max: f32) -> f32 {
+    min + (max - min) * random_float()
 }
 
 pub fn random_vector_range(min: f32, max: f32) -> Vector3<f32> {
@@ -23,48 +19,5 @@ pub fn random_vector_range(min: f32, max: f32) -> Vector3<f32> {
         random_float_range(min, max),
         random_float_range(min, max),
         random_float_range(min, max),
-    )
-}
-pub fn random_in_unit_disk() -> Vector3<f32> {
-    loop {
-        let p = Vector3::new(
-            random_float_range(-1.0, 1.0),
-            random_float_range(-1.0, 1.0),
-            0.0,
-        );
-        if p.magnitude_squared() < 1.0 {
-            return p;
-        }
-    }
-}
-pub fn reflect(v: &Vector3<f32>, n: &Vector3<f32>) -> Vector3<f32> {
-    v - 2.0 * v.dot(&n) * n
-}
-pub fn refract(uv: &Vector3<f32>, n: &Vector3<f32>, etai_over_etat: f32) -> Vector3<f32> {
-    let cos_theta = -uv.dot(n).min(1.0);
-    let r_out_perp = etai_over_etat * (uv + cos_theta * n);
-    let r_out_parallel = -(1.0 - r_out_perp.magnitude_squared()).abs().sqrt() * n;
-    r_out_perp + r_out_parallel
-}
-
-pub fn random_unit_vector() -> Vector3<f32> {
-    loop {
-        let p: Vector3<f32> = random_vector_range(-1.0, 1.0);
-        let lensq = p.magnitude_squared();
-        if 1e-160 < lensq && lensq <= 1.0 {
-            return p / lensq.sqrt();
-        }
-    }
-}
-pub fn near_zero(v: &Vector3<f32>) -> bool {
-    const S: f32 = 1e-8;
-    v.x.abs() < S && v.y.abs() < S && v.z.abs() < S
-}
-
-pub fn sample_square() -> Vector3<f32> {
-    Vector3::new(
-        random_float() - 0.5,
-        random_float() - 0.5,
-        0.0,
     )
 }


### PR DESCRIPTION
Updated both the `hit()` and `scatter()` method to return an `Option<_>`, rather than a `bool`. This helps avoid the internal mutation of values which is easier to read and reduces method arguments. We can easily unwrap the `Some()` values using `if let ...`.